### PR TITLE
Add Ability To Track Total Fees Paid By Account

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -1,0 +1,21 @@
+package main
+
+import "github.com/ethereum/go-ethereum/common/hexutil"
+
+// Label known rollups who regularly post blob transactions.
+var accountLabels = map[[20]byte]string{
+	mustDecode("0xc1b634853cb333d3ad8663715b08f41a3aec47cc"): "Arbitrum",
+	mustDecode("0x6887246668a3b87f54deb3b94ba47a6f63f32985"): "Optimism",
+	mustDecode("0x5050f69a9786f081509234f1a7f4684b5e5b76c9"): "Base",
+	mustDecode("0x000000633b68f5d8d3a86593ebb815b4663bcbe0"): "Taiko",
+	mustDecode("0x2c169dfe5fbba12957bdd0ba47d9cedbfe260ca7"): "Starknet",
+	mustDecode("0x0D3250c3D5FAcb74Ac15834096397a3Ef790ec99"): "ZkSync",
+	mustDecode("0xcf2898225ed05be911d3709d9417e86e0b4cfc8f"): "Scroll",
+	mustDecode("0x415c8893d514f9bc5211d36eeda4183226b84aa7"): "Blast",
+	mustDecode("0xa9268341831efa4937537bc3e9eb36dbece83c7e"): "Linea",
+}
+
+func mustDecode(address string) [20]byte {
+	byteAddr := hexutil.MustDecode(address)
+	return [20]byte(byteAddr)
+}

--- a/dashboard/BlobWatcher Dashboard.json
+++ b/dashboard/BlobWatcher Dashboard.json
@@ -948,6 +948,208 @@
       ],
       "title": "Included Blob Transaction Tip(Account)",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "cdpm0r0qz6328a"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "In Gwei",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "cdpm0r0qz6328a"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "increase(blob_transaction_fees_paid_sum[30s])/increase(blob_transaction_fees_paid_count[30s])",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{account}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Blob Transaction Fees Paid",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "cdpm0r0qz6328a"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "In Gwei",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 40
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "cdpm0r0qz6328a"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "increase(blob_transaction_fees_paid_sum{account=\"$Account\"}[30s])/increase(blob_transaction_fees_paid_count{account=\"$Account\"}[30s])",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "$Account",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Blob Transaction Fees Paid(Account)",
+      "type": "timeseries"
     }
   ],
   "refresh": "",
@@ -957,7 +1159,7 @@
     "list": [
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": [
             "Arbitrum"
           ],
@@ -990,7 +1192,7 @@
     ]
   },
   "time": {
-    "from": "now-30m",
+    "from": "now-1h",
     "to": "now"
   },
   "timeRangeUpdatedDuringEditOrView": false,
@@ -998,6 +1200,6 @@
   "timezone": "browser",
   "title": "BlobWatcher Dashboard",
   "uid": "bdpm1e8v5m48we",
-  "version": 21,
+  "version": 22,
   "weekStart": ""
 }

--- a/main.go
+++ b/main.go
@@ -3,13 +3,11 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
 	"math/big"
 	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -119,7 +117,7 @@ func main() {
 				r, err := ec.TransactionReceipt(context.Background(), hash)
 				if err == nil && r.BlockHash == h.Hash() {
 					log.WithFields(txData(tx, chainID)).Infof("Transaction was included in block %d in %s", r.BlockNumber.Uint64(), time.Since(txTime[hash]))
-					recordTxInclusion(tx, chainID, time.Since(txTime[hash]))
+					recordTxInclusion(r, tx, chainID, time.Since(txTime[hash]))
 					blobsIncluded += len(tx.BlobHashes())
 					delete(pendingTxs, hash)
 					delete(txTime, hash)
@@ -168,73 +166,4 @@ func main() {
 			log.Infof("*/-------------------------------------------------------------------------------------------------------------------------------------------------------------------*/")
 		}
 	}
-}
-
-func txData(tx *gethtypes.Transaction, chainID *big.Int) log.Fields {
-	acc, err := gethtypes.Sender(gethtypes.NewCancunSigner(chainID), tx)
-	if err != nil {
-		log.WithError(err).Error("Could not get sender's account address")
-		return nil
-	}
-	accName := acc.String()
-	if name, ok := accountLabels[[20]byte(acc.Bytes())]; ok {
-		accName = name
-	}
-
-	return log.Fields{
-		"TxHash":              tx.Hash(),
-		"BlobGasFeeCap(Gwei)": float64(tx.BlobGasFeeCap().Uint64()) / params.GWei,
-		"BlobGas":             tx.BlobGas(),
-		"BlobCount":           len(tx.BlobHashes()),
-		"GasFeeCap(Gwei)":     float64(tx.GasFeeCap().Uint64()) / params.GWei,
-		"GasTipCap(Gwei)":     float64(tx.GasTipCap().Uint64()) / params.GWei,
-		"Gas":                 tx.Gas(),
-		"Account":             accName,
-	}
-}
-
-var accountLabels = map[[20]byte]string{
-	mustDecode("0xc1b634853cb333d3ad8663715b08f41a3aec47cc"): "Arbitrum",
-	mustDecode("0x6887246668a3b87f54deb3b94ba47a6f63f32985"): "Optimism",
-	mustDecode("0x5050f69a9786f081509234f1a7f4684b5e5b76c9"): "Base",
-	mustDecode("0x000000633b68f5d8d3a86593ebb815b4663bcbe0"): "Taiko",
-	mustDecode("0x2c169dfe5fbba12957bdd0ba47d9cedbfe260ca7"): "Starknet",
-	mustDecode("0x0D3250c3D5FAcb74Ac15834096397a3Ef790ec99"): "ZkSync",
-	mustDecode("0xcf2898225ed05be911d3709d9417e86e0b4cfc8f"): "Scroll",
-	mustDecode("0x415c8893d514f9bc5211d36eeda4183226b84aa7"): "Blast",
-	mustDecode("0xa9268341831efa4937537bc3e9eb36dbece83c7e"): "Linea",
-}
-
-func mustDecode(address string) [20]byte {
-	byteAddr := hexutil.MustDecode(address)
-	return [20]byte(byteAddr)
-}
-
-func recordTxMetrics(tx *gethtypes.Transaction, chainID *big.Int) {
-	acc, err := gethtypes.Sender(gethtypes.NewCancunSigner(chainID), tx)
-	if err != nil {
-		log.WithError(err).Error("Could not get sender's account address")
-		return
-	}
-	accName := acc.String()
-	if name, ok := accountLabels[[20]byte(acc.Bytes())]; ok {
-		accName = name
-	}
-	transactionsObservedGauge.WithLabelValues(accName, fmt.Sprintf("%d", len(tx.BlobHashes())), fmt.Sprintf("%d", tx.BlobGasFeeCap().Uint64())).Inc()
-}
-
-func recordTxInclusion(tx *gethtypes.Transaction, chainID *big.Int, inclusionDelay time.Duration) {
-	acc, err := gethtypes.Sender(gethtypes.NewCancunSigner(chainID), tx)
-	if err != nil {
-		log.WithError(err).Error("Could not get sender's account address")
-		return
-	}
-	accName := acc.String()
-	if name, ok := accountLabels[[20]byte(acc.Bytes())]; ok {
-		accName = name
-	}
-	gasTip, _ := tx.GasTipCap().Float64()
-	gasTipGwei := gasTip / params.GWei
-	transactionInclusionDelay.WithLabelValues(accName, fmt.Sprintf("%d", len(tx.BlobHashes()))).Observe(inclusionDelay.Seconds())
-	transactionTip.WithLabelValues(accName, fmt.Sprintf("%d", len(tx.BlobHashes()))).Observe(gasTipGwei)
 }

--- a/metrics.go
+++ b/metrics.go
@@ -23,6 +23,14 @@ var (
 		},
 		[]string{"account", "blobCount"},
 	)
+	blobTransactionFeesPaid = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "blob_transaction_fees_paid",
+			Help:    "The transaction fees paid by the account for the blob transaction(in Gwei)",
+			Buckets: []float64{0.001, 0.01, 1, 10, 1000, 100000, 10000000, 1000000000, 10000000000, 1000000000000},
+		},
+		[]string{"account", "blobCount"},
+	)
 	blockNumberGauge = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "block_number",
 		Help: "The current block number in your execution client",

--- a/transaction.go
+++ b/transaction.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"fmt"
+	"math/big"
+	"time"
+
+	gethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+	log "github.com/sirupsen/logrus"
+)
+
+func recordTxMetrics(tx *gethtypes.Transaction, chainID *big.Int) {
+	acc, err := gethtypes.Sender(gethtypes.NewCancunSigner(chainID), tx)
+	if err != nil {
+		log.WithError(err).Error("Could not get sender's account address")
+		return
+	}
+	accName := acc.String()
+	if name, ok := accountLabels[[20]byte(acc.Bytes())]; ok {
+		accName = name
+	}
+	transactionsObservedGauge.WithLabelValues(accName, fmt.Sprintf("%d", len(tx.BlobHashes())), fmt.Sprintf("%d", tx.BlobGasFeeCap().Uint64())).Inc()
+}
+
+func recordTxInclusion(receipt *gethtypes.Receipt, tx *gethtypes.Transaction, chainID *big.Int, inclusionDelay time.Duration) {
+	acc, err := gethtypes.Sender(gethtypes.NewCancunSigner(chainID), tx)
+	if err != nil {
+		log.WithError(err).Error("Could not get sender's account address")
+		return
+	}
+	accName := acc.String()
+	if name, ok := accountLabels[[20]byte(acc.Bytes())]; ok {
+		accName = name
+	}
+	gasTip, _ := tx.GasTipCap().Float64()
+	gasTipGwei := gasTip / params.GWei
+	transactionInclusionDelay.WithLabelValues(accName, fmt.Sprintf("%d", len(tx.BlobHashes()))).Observe(inclusionDelay.Seconds())
+	transactionTip.WithLabelValues(accName, fmt.Sprintf("%d", len(tx.BlobHashes()))).Observe(gasTipGwei)
+	blobTransactionFeesPaid.WithLabelValues(accName, fmt.Sprintf("%d", len(tx.BlobHashes()))).Observe(costOfTx(receipt, tx))
+}
+
+func txData(tx *gethtypes.Transaction, chainID *big.Int) log.Fields {
+	acc, err := gethtypes.Sender(gethtypes.NewCancunSigner(chainID), tx)
+	if err != nil {
+		log.WithError(err).Error("Could not get sender's account address")
+		return nil
+	}
+	accName := acc.String()
+	if name, ok := accountLabels[[20]byte(acc.Bytes())]; ok {
+		accName = name
+	}
+
+	return log.Fields{
+		"TxHash":              tx.Hash(),
+		"BlobGasFeeCap(Gwei)": float64(tx.BlobGasFeeCap().Uint64()) / params.GWei,
+		"BlobGas":             tx.BlobGas(),
+		"BlobCount":           len(tx.BlobHashes()),
+		"GasFeeCap(Gwei)":     float64(tx.GasFeeCap().Uint64()) / params.GWei,
+		"GasTipCap(Gwei)":     float64(tx.GasTipCap().Uint64()) / params.GWei,
+		"Gas":                 tx.Gas(),
+		"Account":             accName,
+	}
+}
+
+func costOfTx(receipt *gethtypes.Receipt, tx *gethtypes.Transaction) float64 {
+	total := new(big.Int).Mul(receipt.EffectiveGasPrice, new(big.Int).SetUint64(receipt.GasUsed))
+	total.Add(total, new(big.Int).Mul(receipt.BlobGasPrice, new(big.Int).SetUint64(receipt.BlobGasUsed)))
+
+	total.Add(total, tx.Value())
+	fTotal, _ := total.Float64()
+	return fTotal / params.GWei
+}


### PR DESCRIPTION
This PR adds the ability to track the total fees incurred by an account/rollup in posting data to ethereum mainnet using blob transactions. Using the fees posted a few panels were built to track this for each transaction. These have also been added into the PR.

![image](https://github.com/OffchainLabs/Blobwatcher/assets/33201827/1b4afa3f-2899-4715-9479-cf0ee25c0bac)
![image](https://github.com/OffchainLabs/Blobwatcher/assets/33201827/a29e0e9b-c7be-47c4-ae50-b9046351566e)
